### PR TITLE
Changes the constituency ordering to be alphabetic

### DIFF
--- a/electionleaflets/apps/constituencies/views.py
+++ b/electionleaflets/apps/constituencies/views.py
@@ -37,7 +37,7 @@ class ConstituencyList(ListView, FormView):
     form_class = ConstituencyLookupForm
     queryset = Constituency.objects.all()\
                .annotate(num_leaflets=Count('leaflet'))\
-               .order_by('-num_leaflets')
+               .order_by('name')
 
     def get(self, request, *args, **kwargs):
         form_class = self.get_form_class()


### PR DESCRIPTION
Should fix #42 by changing ordering from number of leaflets desc to name.

This is a cached view, so probably won't show up straight-away.