### PR TITLE
Template leaflet titles

### DIFF
--- a/electionleaflets/templates/leaflets/full.html
+++ b/electionleaflets/templates/leaflets/full.html
@@ -1,11 +1,11 @@
 {% extends "base.html" %}
 
 {% block content %}
-    <a href="{% url "leaflet" object.leaflet.pk %}">&larr; back to details of <em>{{ object.leaflet.get_title }}</em></a>
+    <a href="{% url "leaflet" object.leaflet.pk %}">&larr; back to {{ object.leaflet.get_title|default_if_none:"leaflet" }} details</a>
     <figure>
         <img src="{{ object.image.url }}" />
         <figcaption>
-            {{ object.leaflet.get_title }}
+            {{ object.leaflet.get_title|default_if_none:"" }}
         </figcaption>
     </figure>
     {# <a href="{% url "leaflet" leaflet.id %}">&larr; back to details of <em>{{ leaflet.title }}</em></a> #}

--- a/electionleaflets/templates/leaflets/full_all.html
+++ b/electionleaflets/templates/leaflets/full_all.html
@@ -12,7 +12,7 @@
 
 {% block content %}
     {% include "leaflets/includes/leaflet_admin_markup_tools.html" %}
-    <a href="{% url "leaflet" leaflet.id%}">&larr; back to details of <em>{{ leaflet.title }}</em></a>
+    <a href="{% url "leaflet" leaflet.id%}">&larr; back to {{ leaflet.get_title|default_if_none:"leaflet" }} details</a>
 
     {% for image in leaflet.images.all %}
         <figure id="image-{{ image.pk }}">

--- a/electionleaflets/templates/leaflets/image_crop.html
+++ b/electionleaflets/templates/leaflets/image_crop.html
@@ -8,13 +8,13 @@
 {% endblock %}
 
 {% block content %}
-    <a href="{% url "leaflet" object.leaflet.pk %}">&larr; back to details of <em>{{ object.leaflet.get_title }}</em></a>
+    <a href="{% url "leaflet" object.leaflet.pk %}">&larr; back to {{ object.leaflet.get_title|default_if_none:"leaflet" }} details</a>
     <figure>
         <img src="{{ object.raw_image.url }}" />
     </figure>
 
 
-<form method=post>    
+<form method=post>
     <input type="hidden" name="x" value="">
     <input type="hidden" name="y" value="">
     <input type="hidden" name="x2" value="">

--- a/electionleaflets/templates/leaflets/image_rotate.html
+++ b/electionleaflets/templates/leaflets/image_rotate.html
@@ -5,7 +5,7 @@
 {% block body_class %}class="rotate"{% endblock %}
 
 {% block content %}
-    <a href="{% url "leaflet" object.leaflet.pk %}">&larr; back to details of <em>{{ object.leaflet.get_title }}</em></a>
+    <a href="{% url "leaflet" object.leaflet.pk %}">&larr; back to {{ object.leaflet.get_title|default_if_none:"leaflet" }} details</a>
     <form method=post>
         <input type="hidden" name="rotate" value="0" id="rotate">
         <button type=submit>Rotate</button>


### PR DESCRIPTION
Should fix #41 by making sure it handles the default (of None).  

Presumably titles are missing on non-legacy leaflets because it isn't collected.  