### PR TITLE
Invalid postcode on constituency page

### DIFF
--- a/electionleaflets/apps/constituencies/forms.py
+++ b/electionleaflets/apps/constituencies/forms.py
@@ -1,7 +1,18 @@
 from django import forms
+from django.utils.translation import ugettext as _
+
+from core.helpers import geocode
 
 from localflavor.gb.forms import GBPostcodeField
 
 class ConstituencyLookupForm(forms.Form):
     postcode = GBPostcodeField(label="Search by postcode",
         error_messages={'invalid': 'Please enter a full UK postcode'})
+    location = None
+
+    def clean(self):
+        cleaned_data = super(ConstituencyLookupForm, self).clean()
+        pcode = cleaned_data.get("postcode")
+        self.location = geocode(pcode)
+        if not self.location:
+            raise forms.ValidationError(_("That postcode was not found. Please try another"))

--- a/electionleaflets/apps/constituencies/views.py
+++ b/electionleaflets/apps/constituencies/views.py
@@ -49,8 +49,7 @@ class ConstituencyList(ListView, FormView):
         return self.render_to_response(context)
 
     def form_valid(self, form):
-        location = geocode(form.cleaned_data['postcode'])
-        self.success_url = location['constituency'].get_absolute_url()
+        self.success_url = form.location['constituency'].get_absolute_url()
         return super(ConstituencyList, self).form_valid(form)
 
     def post(self, *args, **kwargs):


### PR DESCRIPTION
If the user specified a well-structured, but non-existent postcode, bad things happened.

Now only good things happen because we added the validation in the form rather than after form validation.

Closes #34 