### PR TITLE
waffle.io Badge

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
+[![Stories in Ready](https://badge.waffle.io/democracyclub/electionleaflets.png?label=ready&title=Ready)](https://waffle.io/democracyclub/electionleaflets)
 # Electionleaflets
 
 [![Build Status](https://travis-ci.org/DemocracyClub/electionleaflets.svg?branch=django_1_7)](https://travis-ci.org/DemocracyClub/electionleaflets)


### PR DESCRIPTION
Merge this to receive a badge indicating the number of issues in the ready column on your waffle.io board at https://waffle.io/democracyclub/electionleaflets

This was requested by a real person (user symroe) on waffle.io, we're not trying to spam you.