### PR TITLE
Ensure that the leaflet map doesn't block the constituency link

### DIFF
--- a/electionleaflets/templates/leaflets/leaflet.html
+++ b/electionleaflets/templates/leaflets/leaflet.html
@@ -141,7 +141,9 @@
           in <a href="{% url "constituency-view"  object.constituency.pk object.constituency.slug %}">{{ object.constituency.name }}</a>
         {% endif %}
         on {{ object.date_uploaded|date:"l, d M, Y" }}.</p>
+        <div>
         <div id="leaflet_map"></div>
+        </div>
       </section>
     </article>
 


### PR DESCRIPTION
Adds an extra parent div, so that the map is confined to that, instead
of the whole leaflet_map section.

Fixes #63