### PR TITLE
Fix migration dependencies

### DIFF
--- a/electionleaflets/apps/leaflets/migrations/0001_initial.py
+++ b/electionleaflets/apps/leaflets/migrations/0001_initial.py
@@ -15,7 +15,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ('elections', '0001_initial'),
         ('constituencies', '0001_initial'),
-        ('uk_political_parties', '0005_auto_20160403_1447'),
+        ('uk_political_parties', '0004_auto_20150322_2250'),
     ]
 
     operations = [

--- a/electionleaflets/apps/people/migrations/0001_initial.py
+++ b/electionleaflets/apps/people/migrations/0001_initial.py
@@ -13,7 +13,7 @@ class Migration(migrations.Migration):
     dependencies = [
         ('elections', '0001_initial'),
         ('constituencies', '0001_initial'),
-        ('uk_political_parties', '0005_auto_20160403_1447'),
+        ('uk_political_parties', '0004_auto_20150322_2250'),
     ]
 
     operations = [


### PR DESCRIPTION
Use the latest migration from the `uk_poltical_parties` app.
`0005_auto_20160403_1447` doesn’t exist there.