### PR TITLE
Fetch Stamen tiles over SSL

### DIFF
--- a/electionleaflets/assets-src/javascript/app/app.js
+++ b/electionleaflets/assets-src/javascript/app/app.js
@@ -28,7 +28,7 @@
     map.doubleClickZoom.disable();
     map.scrollWheelZoom.disable();
 
-    var Stamen_TonerLite = L.tileLayer('http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png', {
+    var Stamen_TonerLite = L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
     	attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     	subdomains: 'abcd',
     }).addTo(map);

--- a/electionleaflets/media/javascript/electionleaflets.main.min.js
+++ b/electionleaflets/media/javascript/electionleaflets.main.min.js
@@ -18349,7 +18349,7 @@ var firstAvailCol;if(typeof(matrix[rowIndex])=="undefined"){matrix[rowIndex]=[];
     map.doubleClickZoom.disable();
     map.scrollWheelZoom.disable();
 
-    var Stamen_TonerLite = L.tileLayer('http://{s}.tile.stamen.com/toner-lite/{z}/{x}/{y}.png', {
+    var Stamen_TonerLite = L.tileLayer('https://stamen-tiles.a.ssl.fastly.net/toner-lite/{z}/{x}/{y}.png', {
     	attribution: 'Map tiles by <a href="http://stamen.com">Stamen Design</a>, <a href="http://creativecommons.org/licenses/by/3.0">CC BY 3.0</a> &mdash; Map data &copy; <a href="http://www.openstreetmap.org/copyright">OpenStreetMap</a>',
     	subdomains: 'abcd',
     }).addTo(map);

--- a/electionleaflets/settings/base.py
+++ b/electionleaflets/settings/base.py
@@ -108,7 +108,7 @@ INSTALLED_APPS = [
     'allauth.socialaccount.providers.facebook',
     'allauth.socialaccount.providers.twitter',
     'aloe_django',
-
+    'sslserver',
 ] + LEAFLET_APPS
 
 

--- a/requirements/dev.txt
+++ b/requirements/dev.txt
@@ -11,3 +11,4 @@ unittest2==0.8.0
 coveralls
 responses==0.3.0
 factory_boy
+django-sslserver


### PR DESCRIPTION
Stamen uses Fastly to serve tiles over SSL. There’s no need to serve
them over HTTP in dev mode, so just use Fastly over SSL regardless.

Fixes #112 