### PR TITLE
Revert "Add django_extensions"

### DIFF
--- a/electionleaflets/settings/base.py
+++ b/electionleaflets/settings/base.py
@@ -109,7 +109,6 @@ INSTALLED_APPS = [
     'allauth.socialaccount.providers.twitter',
     'aloe_django',
     'sslserver',
-    'django_extensions',
 ] + LEAFLET_APPS
 
 

--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -34,4 +34,3 @@ sorl-thumbnail==v12.4a1
 sure==1.2.9
 boto==2.38.0
 git+https://github.com/DemocracyClub/django-uk-political-parties.git#egg=django-uk-political-parties
-django-extensions


### PR DESCRIPTION
This reverts commit e0ca396f1ea2ee91fe1b0d8d9c68ec46b08cdcf4.

This isn't currently being used and is causing errors when running migrations

cc @symroe 