### PR TITLE
Upgrade django-extensions to 1.7.9

### DIFF
--- a/requirements/base.txt
+++ b/requirements/base.txt
@@ -6,7 +6,7 @@ django-appconf==0.6
 django-allauth==0.25.2
 django-braces==1.8.0
 django-compressor==1.2
-django-extensions==1.4.8
+django-extensions==1.7.9
 django-formtools
 django-localflavor==1.1
 git+https://github.com/zyga/django-pagination.git#egg=linaro_django_pagination
@@ -34,4 +34,3 @@ sorl-thumbnail==v12.4a1
 sure==1.2.9
 boto==2.38.0
 git+https://github.com/DemocracyClub/django-uk-political-parties.git#egg=django-uk-political-parties
-django-extensions


### PR DESCRIPTION
1.4.8 depends on South, which is unsupported in Django 1.9. Also remove
the duplicate requirement.

This issue was introduced in e0ca396f1ea2ee91fe1b0d8d9c68ec46b08cdcf4