### PR TITLE
Add Mapit key

### DIFF
--- a/electionleaflets/apps/core/constants.py
+++ b/electionleaflets/apps/core/constants.py
@@ -1,1 +1,0 @@
-MAPIT_URL = "https://mapit.mysociety.org"

--- a/electionleaflets/settings/base.py
+++ b/electionleaflets/settings/base.py
@@ -183,6 +183,9 @@ THANKYOU_MESSAGES = [
 
 TEST_RUNNER = 'django.test.runner.DiscoverRunner'
 
+MAPIT_API_KEY = environ.get('MAPIT_API_KEY', None)
+MAPIT_API_URL = environ.get('MAPIT_API_URL', 'https://mapit.democracyclub.org.uk/')
+
 # .local.py overrides all the common settings.
 try:
     from .local import *


### PR DESCRIPTION
Use a Mapit API key for postcode lookups if supplied. Also send the exception to Sentry if one is raised