### PR TITLE
Fix storage backends

### DIFF
--- a/electionleaflets/apps/leaflets/views.py
+++ b/electionleaflets/apps/leaflets/views.py
@@ -19,7 +19,7 @@ from analysis.forms import QuestionSetForm
 from people.models import Person
 from .models import Leaflet, LeafletImage
 from .forms import (InsidePageImageForm, LeafletDetailsFrom)
-from s3_lambda_storage import S3LambdaStorage
+from storages.backends.s3boto3 import S3Boto3Storage
 
 
 class ImageView(DetailView):
@@ -153,7 +153,7 @@ class LeafletUploadWizzard(NamedUrlSessionWizardView):
     }
 
     if os.environ.get('AWS_SESSION_TOKEN', None):
-        file_storage = S3LambdaStorage(location='leaflets_tmp')
+        file_storage = S3Boto3Storage(location='leaflets_tmp')
     else:
         file_storage = FileSystemStorage(location=os.path.join(
             settings.MEDIA_ROOT, 'images/leaflets_tmp'))

--- a/electionleaflets/settings/zappa.py
+++ b/electionleaflets/settings/zappa.py
@@ -25,8 +25,8 @@ DEFAULT_FROM_EMAIL = 'hello@democracyclub.org.uk'
 AWS_SES_REGION_NAME = 'eu-west-1'
 AWS_SES_REGION_ENDPOINT = 'email.eu-west-1.amazonaws.com'
 
-DEFAULT_FILE_STORAGE = 's3_lambda_storage.S3LambdaStorage'
-STATICFILES_STORAGE = 's3_lambda_storage.S3StaticLambdaStorage'
+DEFAULT_FILE_STORAGE = 'storages.backends.s3boto3.S3Boto3Storage'
+STATICFILES_STORAGE = 's3_lambda_storage.S3StaticStorage'
 AWS_STORAGE_BUCKET_NAME = "data.electionleaflets.org"
 AWS_S3_SECURE_URLS = True
 AWS_S3_HOST = 's3-eu-west-1.amazonaws.com'

--- a/electionleaflets/third_party/s3_lambda_storage.py
+++ b/electionleaflets/third_party/s3_lambda_storage.py
@@ -1,24 +1,8 @@
-import boto3
 from django.conf import settings
 from storages.backends.s3boto3 import S3Boto3Storage
 
 
-class S3LambdaStorage(S3Boto3Storage):
-    @property
-    def connection(self):
-        if self._connection is None:
-            session = boto3.session.Session()
-            self._connection = session.resource(
-                self.connection_service_name,
-                region_name=self.region_name,
-                use_ssl=self.use_ssl,
-                endpoint_url=self.endpoint_url,
-                config=self.config
-            )
-        return self._connection
-
-
-class S3StaticLambdaStorage(S3LambdaStorage):
+class S3StaticStorage(S3Boto3Storage):
     def __init__(self, *args, **kwargs):
         kwargs['location'] = settings.STATIC_URL
-        super(S3StaticLambdaStorage, self).__init__(*args, **kwargs)
+        super(S3StaticStorage, self).__init__(*args, **kwargs)


### PR DESCRIPTION
We used to need a subclassed storage backend for Lambda as boto3 didn't
support Session Tokens. These are now supported out of the box so we
can use vanilla S3Boto3Storage. We still need a subclass to set the
location for static files.