### PR TITLE
Fix leaflet JSON API

### DIFF
--- a/electionleaflets/apps/api/serializers.py
+++ b/electionleaflets/apps/api/serializers.py
@@ -46,7 +46,6 @@ class LeafletImageSerializer(serializers.ModelSerializer):
         model = LeafletImage
         fields = (
             'image',
-            'image_text',
             'image_type',
         )
     image = serializers.ImageField()

--- a/electionleaflets/apps/api/views.py
+++ b/electionleaflets/apps/api/views.py
@@ -29,10 +29,7 @@ class LeafletPermissions(BasePermission):
     def has_object_permission(self, request, view, obj):
         # Allow unauthenticated users to GET and POST
         # but not PUT, PATCH and DELETE
-        if request.method in ['GET', 'POST']:
-            return True
-        else:
-            return request.user == obj.owner
+        return request.method in ['GET', 'POST']
 
 
 class ReadOnly(BasePermission):

--- a/electionleaflets/templates/leaflets/leaflet.html
+++ b/electionleaflets/templates/leaflets/leaflet.html
@@ -123,7 +123,7 @@
 
 
         <p>
-            The data on this page is available in <a href="http://{{request.META.HTTP_HOST }}{% url "api:leaflet-detail" object.pk%}?format=json">JSON format</a>. The images of this leaflet
+            The data on this page is available in <a href="{% url "api:leaflet-detail" object.pk%}?format=json">JSON format</a>. The images of this leaflet
             should be considered to be in the public domain, in accordance with
             the <a
             href="https://creativecommons.org/publicdomain/zero/1.0/">Public


### PR DESCRIPTION
We've removed the `image_text` field which was unpopulated, so we
shouldn't try and serialise it.

Leaflets don't have an `owner` so don' t use it to check permissions.

Use a relative URL for the JSON link on the leaflet page, the
`HTTP_HOST` on Lambda will not be the real EL URL and won't work.