### PR TITLE
Never accidentally deploy local settings

### DIFF
--- a/serverless.yml
+++ b/serverless.yml
@@ -50,7 +50,9 @@ package:
     - electionleaflets/apps/**
     - electionleaflets/assets/**
     - electionleaflets/media/**
-    - electionleaflets/settings/**
+    - electionleaflets/settings/__init__.py
+    - electionleaflets/settings/base.py
+    - electionleaflets/settings/zappa.py
     - electionleaflets/templates/**
     - electionleaflets/third_party/**
     - electionleaflets/*


### PR DESCRIPTION
For working on DC locally, we use a `local.py`. When deploying using
`sls`, we zip the local working copy, which may include local settings.
This explicitly specifies the settings files we want to upload.