### PR TITLE
Fix using static assets from plugin apps

### DIFF
--- a/electionleaflets/settings/base.py
+++ b/electionleaflets/settings/base.py
@@ -65,8 +65,8 @@ PIPELINE = get_pipeline_settings(
 
 STATICFILES_FINDERS = (
     'pipeline.finders.ManifestFinder',
-    'pipeline.finders.FileSystemFinder',
-    'pipeline.finders.AppDirectoriesFinder',
+    'django.contrib.staticfiles.finders.FileSystemFinder',
+    'django.contrib.staticfiles.finders.AppDirectoriesFinder',
     'pipeline.finders.PipelineFinder',
 )
 


### PR DESCRIPTION
For static assets that don't require compilation, we need to use the
main contrib finders rather than pipeline's ones, as there's no
rendering to be done.