### PR TITLE
Use GET for resetting form rather than POST

### DIFF
--- a/electionleaflets/apps/leaflets/urls.py
+++ b/electionleaflets/apps/leaflets/urls.py
@@ -1,4 +1,5 @@
 from django.conf.urls import url
+from django.views.decorators.cache import never_cache
 
 from leaflets.views import (ImageView, LatestLeaflets,
                             LeafletView, LeafletUploadWizzard,
@@ -27,8 +28,8 @@ upload_form_wizzard = LeafletUploadWizzard.as_view(
 )
 
 urlpatterns = [
-    url(r'add/(?P<step>.+)/$', upload_form_wizzard, name='upload_step'),
-    url(r'add/', upload_form_wizzard, name='upload_leaflet'),
+    url(r'add/(?P<step>.+)/$', never_cache(upload_form_wizzard), name='upload_step'),
+    url(r'add/', never_cache(upload_form_wizzard), name='upload_leaflet'),
 
     url(r'^full/(?P<pk>\d+)/$', ImageView.as_view(), name='full_image'),
     url(r'^full/(?P<pk>.+)/$', LegacyImageView.as_view(), name='full_image_legacy'),

--- a/electionleaflets/apps/leaflets/views.py
+++ b/electionleaflets/apps/leaflets/views.py
@@ -196,16 +196,13 @@ class LeafletUploadWizzard(NamedUrlSessionWizardView):
         self.extra_added = True
 
     def get(self, *args, **kwargs):
+        if "reset" in self.request.GET:
+            self.storage.reset()
+            return HttpResponseRedirect("/")
         self._insert_extra_inside_forms()
         return super(LeafletUploadWizzard, self).get(*args, **kwargs)
 
     def post(self, *args, **kwargs):
-
-        # Clear the cache if the user presses cancel
-        if self.request.POST.get('cancel_upload', None):
-            self.storage.reset()
-            return HttpResponseRedirect(reverse('home'))
-
         # Add forms to the form_list that we should have.
         # We need to do this on every request, as the extra forms
         # Aren't stored betweet requests, but are held in the session.

--- a/electionleaflets/templates/leaflets/upload_form/leaflet_upload_base.html
+++ b/electionleaflets/templates/leaflets/upload_form/leaflet_upload_base.html
@@ -27,7 +27,7 @@
             <button type="submit" class="secondary expand" name="skip" value="Skip">No more pages</button>
             {% endif %}
 
-            <button type="submit" class="expand secondary" name="cancel_upload" value="Cancel">Cancel</button>
+            <a href="?reset=1" class="link-button expand secondary" style="display:block; text-align:center">Cancel</a>
         </form>
         <p>
           <small>By adding a photograph of a leaflet you are placing that photograph in the <a href="https://creativecommons.org/publicdomain/zero/1.0/">public domain (CC0)</a> as part of the ElectionLeaflets.org archive. This means other people can use it for research, journalism or any other purpose without having to ask permission. Thanks!</small>


### PR DESCRIPTION
I suspect a POST request might fail if a large image exists in the
session, and POSTing it causes another error somewhere before the reset
can happen.

Using GET will remove the chance of POSTing large requests