### PR TITLE
WIP: JS uploads

### DIFF
--- a/electionleaflets/apps/leaflets/static/js/leaflet_uploader.js
+++ b/electionleaflets/apps/leaflets/static/js/leaflet_uploader.js
@@ -1,0 +1,104 @@
+var getCookie = function(name) {
+  var cookieValue = null;
+  if (document.cookie && document.cookie !== '') {
+    var cookies = document.cookie.split(';');
+    for (var i = 0; i < cookies.length; i++) {
+      var cookie = cookies[i].trim();
+      // Does this cookie string begin with the name we want?
+      if (cookie.substring(0, name.length + 1) === (name + '=')) {
+        cookieValue = decodeURIComponent(cookie.substring(name.length + 1));
+        break;
+      }
+    }
+  }
+  return cookieValue;
+};
+var handleError = function(err) {
+    console.debug(err)
+  var error = '<h2>Sorry, something has gone wrong</h2> <p>If the problem continues, ';
+  error += '<a href="mailto:pollingstations@democracyclub.org.uk">contact us</a>.</p>';
+  document.getElementById("error").innerHTML = error;
+  document.getElementById("error").hidden = false;
+  document.getElementById("submit").disabled = false;
+};
+var serializeFile = function(file) {
+  if (file == null) return null;
+  return {
+    name: file.name,
+    size: file.size,
+    type: file.type,
+  };
+};
+var getPresignedPostData = function() {
+  return new Promise(function(resolve, reject) {
+    var xhr = new XMLHttpRequest();
+    var url = '{% url "file_upload_index" %}';
+    xhr.open("POST", url, true);
+    xhr.setRequestHeader("Content-Type", "application/json");
+    xhr.setRequestHeader("X-CSRFToken", getCookie('csrftoken'));
+    var payload = {
+      files: [
+        serializeFile(document.getElementById('id_front-image').files[0]),
+      ].filter(Boolean),
+      upload_session_id: document.getElementById('upload_session_id').value
+    };
+    xhr.send(JSON.stringify(payload));
+    xhr.onload = function() {
+      if (this.status === 200) {
+        resolve(JSON.parse(this.responseText));
+       } else {
+        reject(this.responseText);
+       }
+    };
+  });
+};
+var uploadFileToS3 = function(presignedPostData, file, progressBar) {
+  return new Promise(function(resolve, reject) {
+    var formData = new FormData();
+    Object.keys(presignedPostData.fields).forEach(function(key) {
+      formData.append(key, presignedPostData.fields[key]);
+    });
+    formData.append("file", document.getElementById(file).files[0]);
+    var xhr = new XMLHttpRequest();
+    xhr.open("POST", presignedPostData.url, true);
+    xhr.upload.addEventListener("progress", function(event) {
+      document.getElementById(progressBar).value = (event.loaded / event.total) * 100;
+    }, false);
+    xhr.send(formData);
+    xhr.onload = function() {
+      if (this.status === 204) {
+        resolve(this.responseText);
+      } else {
+        reject(this.responseText);
+      }
+    };
+  });
+};
+document.addEventListener('DOMContentLoaded', function() {
+  document.getElementById('file_upload_form').addEventListener("submit", function (e) {
+    e.preventDefault();
+    document.getElementById("error").innerHTML = "";
+    document.getElementById("error").hidden = true;
+    document.getElementById("submit").disabled = true;
+    getPresignedPostData().then(
+      function(data) {
+        var uploads = [];
+        for (var i=0; i<data.files.length; i++) {
+          uploads.push(
+            uploadFileToS3(data.files[i], 'id_front-image', 'progressBar0')
+          );
+        }
+        Promise.all(uploads).then(
+          function(data) {
+            console.log('done!');
+            console.log(data);
+            document.getElementById("submit").disabled = false;
+
+          },
+          handleError
+        );
+      },
+      handleError
+    );
+  });
+});

--- a/electionleaflets/apps/leaflets/urls.py
+++ b/electionleaflets/apps/leaflets/urls.py
@@ -12,6 +12,7 @@ from leaflets.views import (
     AllImageView,
     ImageRotateView,
     LegacyImageView,
+    FileUploadView,
 )
 
 from .forms import (
@@ -44,6 +45,11 @@ urlpatterns = [
         name="upload_step",
     ),
     url(r"add/", never_cache(upload_form_wizzard), name="upload_leaflet"),
+    url(
+        r"file_upload_index/",
+        never_cache(FileUploadView.as_view()),
+        name="file_upload_index",
+    ),
     url(r"^full/(?P<pk>\d+)/$", ImageView.as_view(), name="full_image"),
     url(
         r"^full/(?P<pk>.+)/$",

--- a/electionleaflets/templates/leaflets/upload_form/leaflet_upload_base.html
+++ b/electionleaflets/templates/leaflets/upload_form/leaflet_upload_base.html
@@ -7,11 +7,14 @@
 {% block content %}
   <div class="upload_form">
     {% block heading %}{% endblock heading %}
+
     <section>
         <header>
             <form action="" method="post" enctype="multipart/form-data"></form>
         </header>
-        <form action="" method="post" enctype="multipart/form-data">
+        <form action="" method="post" id="file_upload_form" enctype="multipart/form-data">
+        <input type="hidden" value="{{ upload_session_id }}", id="upload_session_id">
+            <div id="error"></div>
             {% csrf_token %}
             {{ wizard.management_form }}
             {% block form %}
@@ -20,7 +23,7 @@
             {% if "inside" in wizard.steps.current  %}
             <button type="submit" class="expand" name="add_extra_inside" value="Submit">Submit and add another page</button>
             {% else %}
-            <button type="submit" class="expand" value="Submit">Submit</button>
+            <button type="submit" class="expand" value="Submit" id="submit">Submit</button>
             {% endif %}
 
             {% if wizard.steps.current != "postcode" and wizard.steps.current != "people" and wizard.steps.current != "front" %}


### PR DESCRIPTION
The problem this is trying to solve is to increase the size of leaflet uploads allowed.

The site is hosted on AWS Lambda, and Lambda only allows 5MB of POST data to be sent to it. There is no apparent way around this.

The solution we've used on the WDIV Upload is to use Pre-signed POST requests to upload to S3 directly. This requires making an API request to S3 to get a token, passing that token to some JS that then uploads the image and returns the S3 path back to the upload form that can be POSTed to Django to save the model.

The MVP is to roll our own very simple version of this - the JS code isn't very complex. However, there might be some light weight JS uploaders our there that do some of this already, and support (or can be extended to support) pre-signed POST requests.

Bonus points for the uploader would be to support basic image editing like rotating, cropping etc. This isn't a requirement - we can add it to the post-upload interface - but it would be nice.