### PR TITLE
reject fake host headers

### DIFF
--- a/electionleaflets/settings/base_lambda.py
+++ b/electionleaflets/settings/base_lambda.py
@@ -3,7 +3,7 @@ import os
 from django.urls import set_urlconf
 from .base import *  # noqa: F401,F403
 
-ALLOWED_HOSTS = ["*"]
+ALLOWED_HOSTS = [os.environ.get('APP_DOMAIN')]
 
 DATABASES = {
     "default": {


### PR DESCRIPTION
Currently leaflets allows anything in the host header. This makes the site vulnerable to a range of spoofing attacks. This PR tightens this setting up in line with (for example)

https://github.com/DemocracyClub/Website/blob/fd5b3e57fdef5caac46a7591344bd1ae3b7b3e5b/democracy_club/settings/aws_lambda.py#L17

The `APP_DOMAIN` env var is configured at
https://github.com/DemocracyClub/electionleaflets/blob/38b2f6c46a550ef84f49703df223a5c7e17784e5/template.yaml#L113

Build is failing because I branched off master. I just didn't want to lose sight of this one while I noticed it. We can cherry-pick this somewhere else if it is easier.