### PR TITLE
Fix markdown template tag error

### DIFF
--- a/electionleaflets/apps/core/templatetags/markdown.py
+++ b/electionleaflets/apps/core/templatetags/markdown.py
@@ -6,7 +6,7 @@ register = template.Library()
 
 
 @register.filter(name="markdown")
-def markdown(text):
+def markdown_filter(text):
     return mark_safe(markdown.markdown(text))
 
 

--- a/electionleaflets/apps/leaflets/tests/test_models.py
+++ b/electionleaflets/apps/leaflets/tests/test_models.py
@@ -18,8 +18,11 @@ class LeafletTestCase(TestCase):
         )
 
         self.assertEqual(leaflet._initial["status"], "draft")
-
-
+         
+    def test_markdown_error(self):
+        leaflet = Leaflet.objects.create(title="Test Leaflet", description=None)
+        response = self.client.get(leaflet.get_absolute_url())
+        self.assertEqual(response.status_code, 200)
 
 class LeafletImageTestCase(TestCase):
     @skip("fix me after python and django upgrade")

--- a/electionleaflets/templates/base.html
+++ b/electionleaflets/templates/base.html
@@ -16,6 +16,7 @@
       <meta name="description" lang="en" content="Real-time election leaflet monitoring" />
       <title>{% block title %}Real-time #ElectionLeaflet monitoring{% endblock %} | ElectionLeaflets.org</title>
     {% endblock site_meta %}
+    {% block og_tags %}{% endblock og_tags %}
   </head>
   <body class="ds-scope" style="margin: 0">
     <div class="ds-page">

--- a/electionleaflets/templates/leaflets/leaflet.html
+++ b/electionleaflets/templates/leaflets/leaflet.html
@@ -7,19 +7,17 @@
   <meta property="og:title" content="{{ object.get_title }}"/>
   <meta property="og:type" content="website"/>
   <meta property="og:url" content="{{ leaflet.get_full_url }}"/>
-  <meta name="og:description" content="{{ object.description }}">
-
+  <meta name="og:description" content="{% if object.description %}{{ object.description }}{% else %}Leaflet does not have a description{% endif %}">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@electionspotter">
   <meta name="twitter:creator" content="@electionspotter">
   <meta name="twitter:title" content="{{ object.get_title }}">
-  <meta name="twitter:description" content="{{ object.description|markdown|striptags|truncatechars:"200" }}">
-
+  <meta name="twitter:description" content="{% if object.description %}{{ object.description|markdown|striptags|truncatechars:"200" }}{% else %}Leaflet does not have a description{% endif %}">
   <meta name="twitter:card" content="summary_large_image">
   <meta name="twitter:site" content="@electionspotter">
   <meta name="twitter:creator" content="@electionspotter">
   <meta name="twitter:title" content="{{ object.get_title }}">
-  <meta name="twitter:description" content="{{ object.description|markdown|striptags|truncatechars:"200" }}">
+  <meta name="twitter:description" content="{% if object.description %}{{ object.description|markdown|striptags|truncatechars:"200" }}{% else %}Leaflet does not have a description{% endif %}">
   {% if object.location %}
     <meta property="place:location:latitude" content="{{ object.location.1 }}"/>
     <meta property="place:location:longitude" content="{{ object.location.0 }}"/>
@@ -35,8 +33,8 @@
     {% endthumbnail %}
   {% endfor %}
 {% endblock og_tags %}
-
 {% block content %}
+
   <h1>
     {% if object.get_title %}
       {{ object.get_title }}


### PR DESCRIPTION
Ref https://democracy-club-gp.sentry.io/issues/5935314159

- Added Open Graph meta tags to Leaflet pages for improved social media sharing.
- Implemented conditional rendering for descriptions: displays only when available; otherwise, a default text will ensure compatibility with social media platforms.
- Renamed the markdown filter tag to prevent conflicts with Python, and updated tests to reflect this change.