### PR TITLE
JSON Decode Error

### DIFF
--- a/electionleaflets/apps/leaflets/views.py
+++ b/electionleaflets/apps/leaflets/views.py
@@ -221,6 +221,16 @@ class LeafletUploadWizzard(NamedUrlSessionWizardView):
                 images_text = self.storage.get_step_data("images")[
                     "images-image"
                 ]
+                try:
+                    uploaded_images = json.loads(images_text)
+                except json.JSONDecodeError:
+                    messages.error(
+                        self.request,
+                        "There was an error processing the leaflet images. Please ensure Javascript is enabled and try again.",
+                    )
+                    leaflet.delete()
+                    return redirect(reverse("upload_leaflet"))
+                
                 uploaded_images = json.loads(images_text)
                 bucket = self.storage.file_storage.bucket
                 for file_path in uploaded_images:

--- a/electionleaflets/templates/base.html
+++ b/electionleaflets/templates/base.html
@@ -18,6 +18,12 @@
     {% endblock site_meta %}
   </head>
   <body class="ds-scope" style="margin: 0">
+    <noscript>
+        <div class="ds-status-error">
+            JavaScript is disabled in your browser. Please enable JavaScript to upload leaflets.
+        </div>
+    </noscript>
+  
     <div class="ds-page">
       <p><a class="ds-skip-link" href="#main">skip to content</a></p>
       <header class="ds-header">


### PR DESCRIPTION
Ref https://democracy-club-gp.sentry.io/issues/5934903841?project=163593

The issue is that Lambda functions have a limited capacity for processing file sizes. To work around this, we upload files directly to S3 and then have the Lambda function process the image from there. Refactoring the process to use S3 without JavaScript—particularly for handling multiple file uploads—will require additional planning and design.

This update addresses the exception by notifying users of the JavaScript requirements. I’ve added this notice both on the home page and at the final step of the uploader process to ensure full coverage, even if users disable JavaScript midway through. While the latter may be unnecessary, it ensures this error won't occur again.

---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208447767723083