### PR TITLE
Feat/basic auth lambda 1

### DIFF
--- a/public-access-template.yaml
+++ b/public-access-template.yaml
@@ -27,7 +27,7 @@ Resources:
 
           - Id: Static
             DomainName:
-              Fn::ImportValue: !Sub "ElectionLeafletsApp-${StackNameSuffix}:ElectionLeafletsFqdn"
+              Fn::ImportValue: !Sub "ElectionLeafletsApp-${StackNameSuffix}:ElectionLeafletsFqdnTempValue"
             OriginPath: "/Prod"
             CustomOriginConfig:
               OriginProtocolPolicy: "https-only"
@@ -43,7 +43,7 @@ Resources:
 
           - Id: Dynamic
             DomainName:
-              Fn::ImportValue: !Sub "ElectionLeafletsApp-${StackNameSuffix}:ElectionLeafletsFqdn"
+              Fn::ImportValue: !Sub "ElectionLeafletsApp-${StackNameSuffix}:ElectionLeafletsFqdnTempValue"
             OriginPath: "/Prod"
             CustomOriginConfig:
               OriginProtocolPolicy: "https-only"

--- a/template.yaml
+++ b/template.yaml
@@ -64,7 +64,7 @@ Parameters:
     Description: "The password for the postgres user"
     Type: String
 
-  AppDCEnvironment:
+  DCEnvironment:
     Default: DC_ENVIRONMENT
     Description: "The DC_ENVIRONMENT environment variable passed to the app."
     Type: AWS::SSM::Parameter::Value<String>
@@ -110,7 +110,7 @@ Resources:
           DATABASE_HOST: !Ref AppPostgresHost
           POSTGRES_DATABASE_NAME: !Ref AppPostgresDatabaseName
           DATABASE_PASS: !Ref AppPostgresPassword
-          DC_ENVIRONMENT: !Ref AppDCEnvironment
+          DC_ENVIRONMENT: !Ref DCEnvironment
           APP_DOMAIN: !Ref AppDomain
           LEAFLET_IMAGES_BUCKET_NAME: !Ref AppLeafletImagesBucketName
       Events:

--- a/template.yaml
+++ b/template.yaml
@@ -122,10 +122,19 @@ Resources:
         HTTPRequestRoots:
           Type: Api
           Properties:
+            RestApiId: !Ref ElectionLeafletsAPIGateway
             Path: /
             Method: ANY
 
-
+  ElectionLeafletsAPIGateway:
+    Type: AWS::Serverless::Api
+    Properties:
+      AlwaysDeploy: True
+      StageName: Prod
+      Cors:
+        AllowMethods: "'GET'"
+        AllowOrigin: "'*'"
+        MaxAge: "'600'"
 
   ElectionLeafletsFunctionLogGroup:
     Type: AWS::Logs::LogGroup
@@ -140,3 +149,9 @@ Outputs:
     Value: !Sub "${ServerlessRestApi}.execute-api.${AWS::Region}.amazonaws.com"
     Export:
       Name: !Join [ ":", [ !Ref "AWS::StackName", "ElectionLeafletsFqdn" ] ]
+
+  ElectionLeafletsFqdnTempValue:
+    Description: "API Gateway endpoint FQDN for EC API function"
+    Value: !Sub "${ElectionLeafletsAPIGateway}.execute-api.${AWS::Region}.amazonaws.com"
+    Export:
+      Name: !Join [ ":", [ !Ref "AWS::StackName", "ElectionLeafletsFqdnTempValue" ] ]


### PR DESCRIPTION
Part of larger project: https://app.asana.com/0/1204880927741389/1208294218492449/f

This PR:

- Makes an explicit API gateway resource to replace the implicitly created one
- Adds a basic auth lambda authorizer to the API gateway in development and staging environments

I need to make two sequential deploys for the same the reason as https://github.com/DemocracyClub/ec-api-proxy/pull/232.

The PR for the 2nd deploy is here: https://github.com/DemocracyClub/electionleaflets/pull/304

Testing:

I've tested this by deploying both PRs to the staging branch. The frontend will temporarily break between the deploys.

During deploy:

I had to make changes to the dev CircleCi User permissions in order for it to be able to deploy successfully. I may need to do the same for the stage and prod CI users too.

After deploy:

I'll need to deploy the API gateway stage in the console for dev and staging to apply the changes I've made.
I'll need to make a final cleanup PR to remove the leftover temporary output in the application template



---
- To see the specific tasks where the Asana app for GitHub is being used, see below:
  - https://app.asana.com/0/0/1208397645646737