### PR TITLE
Optimise image serving

### DIFF
--- a/electionleaflets/settings/base_lambda.py
+++ b/electionleaflets/settings/base_lambda.py
@@ -41,7 +41,7 @@ set_urlconf(ROOT_URLCONF)  # noqa: F405
 
 AWS_DEFAULT_ACL = "public-read"
 
-DEFAULT_FILE_STORAGE = "storages.backends.s3boto3.S3Boto3Storage"
+DEFAULT_FILE_STORAGE = "electionleaflets.storages.TempUploadS3MediaStorage"
 
 AWS_STORAGE_BUCKET_NAME = os.environ.get("LEAFLET_IMAGES_BUCKET_NAME")
 AWS_S3_SECURE_URLS = True

--- a/public-access-template.yaml
+++ b/public-access-template.yaml
@@ -97,12 +97,34 @@ Resources:
         Comment: 'Cloudfront Distribution serving leaflet images'
         Origins:
           - Id: "ImagesBucket"
-            DomainName: !Join ['', [!Ref LeafletsBucketName, '.s3.amazonaws.com']]
+            DomainName: !Join [ '', [ !Ref LeafletsBucketName, '.s3.amazonaws.com' ] ]
             CustomOriginConfig:
               OriginProtocolPolicy: "https-only"
 
             OriginShield:
               Enabled: false
+
+          - Id: "ImagesBucketNoLambda"
+            DomainName: !Join [ '', [ !Ref LeafletsBucketName, '.s3.amazonaws.com' ] ]
+            CustomOriginConfig:
+              OriginProtocolPolicy: "https-only"
+
+            OriginShield:
+              Enabled: false
+
+        OriginGroups:
+          Quantity: 1
+          Items:
+            - Id: "ImagesOriginGroup"
+              FailoverCriteria:
+                StatusCodes:
+                  Quantity: 1
+                  Items: [404]
+              Members:
+                Quantity: 2
+                Items:
+                  - OriginId: "ImagesBucketNoLambda"
+                  - OriginId: "ImagesBucket"
 
         Enabled: true
         HttpVersion: 'http2'

--- a/thumbs/attach_lambda_triggers.py
+++ b/thumbs/attach_lambda_triggers.py
@@ -80,7 +80,7 @@ version = lambda_client_us.publish_version(
 )
 version_arn = version["FunctionArn"]
 config = cf_client.get_distribution_config(Id=dist["Id"])
-config["DistributionConfig"]["CacheBehaviors"]["Items"][0][
+config["DistributionConfig"]["CacheBehaviors"]["Items"][-1][
     "LambdaFunctionAssociations"
 ] = {
     "Quantity": 1,


### PR DESCRIPTION
Before this change, we would invoke the thumbs Lambda on each image response. 

This means bootstrapping Django every time we invoke the function, so it was very slow and cost more money / compute.

We can't conditionally invoke a Lambda@Edge function, but we can try S3 first and failover to the origin with the function attached. This is what I'm doing here.


