### PR TITLE
Use larger image on leaflet pages

### DIFF
--- a/electionleaflets/templates/leaflets/leaflet.html
+++ b/electionleaflets/templates/leaflets/leaflet.html
@@ -46,7 +46,7 @@
   {% for image in object.images.all %}
     <figure class="ds-card">
       <div class="ds-card-image">
-        {% thumbnail image.image "600" crop="center" as im %}
+        {% thumbnail image.image "1000" crop="center" as im %}
           <img src="{{ im.url }}" aria-labelledby="page-{{ image.id }}" data-full_image_url="{{ image.image.url }}">
         {% endthumbnail %}
       </div>


### PR DESCRIPTION
The 600 width image was too small, 1000 is a better size.

This is a thumb size we're already making, so there's no work to be done here in making new thumbnails
