### PR TITLE
Fix YNR URL and extend date range

### DIFF
--- a/electionleaflets/apps/core/helpers.py
+++ b/electionleaflets/apps/core/helpers.py
@@ -25,12 +25,13 @@ class YNRAPIHelper:
         self.API_KEY = api_key or settings.YNR_API_KEY  # handy for mocking URLs
 
     def get(self, endpoint, params=None, version="next", json=True):
-        path = urljoin(version, endpoint)
+        path = f"api/{version}/{endpoint}"
         url = urljoin(self.YNR_BASE, path)
         params = params or {}
         params["auth_token"] = self.API_KEY
         resp = requests.get(url, params=params)
         resp.raise_for_status()
+
         if json:
             return resp.json()
         return resp

--- a/electionleaflets/apps/core/tests/test_helpers.py
+++ b/electionleaflets/apps/core/tests/test_helpers.py
@@ -1,0 +1,23 @@
+from unittest.mock import patch
+
+from core.helpers import YNRAPIHelper
+
+
+def test_ynr_get(settings):
+    settings.YNR_BASE_URL = "https://example.com/"
+    ynr_api_key = "test_api_key"
+    endpoint = "ballots"
+    expected_url = "https://example.com/api/next/ballots"
+    expected_params = {"auth_token": ynr_api_key}
+
+    api_helper = YNRAPIHelper(api_key=ynr_api_key)
+
+    with patch("requests.get") as mock_get:
+        mock_response = mock_get.return_value
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {"results": []}
+
+        result = api_helper.get(endpoint)
+
+        mock_get.assert_called_once_with(expected_url, params=expected_params)
+        assert result == {"results": []}

--- a/electionleaflets/apps/leaflets/forms.py
+++ b/electionleaflets/apps/leaflets/forms.py
@@ -122,7 +122,7 @@ class YNRBallotDataMixin:
         for_date = self.FOR_DATE
         if not for_date:
             for_date = timezone.now()
-        start = (for_date - timedelta(days=60)).date().isoformat()
+        start = (for_date - timedelta(days=900)).date().isoformat()
         end = (for_date + timedelta(days=60)).date().isoformat()
         return (start, end)
 
@@ -280,7 +280,7 @@ class UpdatePublisherDetails(YNRBallotDataMixin, forms.ModelForm):
 
     def get_date_range(self):
         start = (
-            (self.instance.date_uploaded - timedelta(days=60))
+            (self.instance.date_uploaded - timedelta(days=900))
             .date()
             .isoformat()
         )

--- a/electionleaflets/settings/base.py
+++ b/electionleaflets/settings/base.py
@@ -248,7 +248,7 @@ TEST_RUNNER = "django.test.runner.DiscoverRunner"
 
 DEVS_DC_AUTH_TOKEN = environ.get("DEVS_DC_AUTH_TOKEN", None)
 YNR_API_KEY = None
-YNR_BASE_URL = "https://candidates.democracyclub.org.uk"
+YNR_BASE_URL = "https://candidates.democracyclub.org.uk/"
 
 if "testing" not in environ.get("DJANGO_SETTINGS_MODULE", ""):
     # .local.py overrides all the common settings.


### PR DESCRIPTION
Couple of things: 

I was wondering why I didn't get name appearing for leaflets I uploaded. Turns out the URL was wrong, so we weren't getting any results.

Second, I thought that we can afford to look back in time a lot longer: we do get leaflets uploaded by people who were elected in the last couple of years. This isn't a _very_ good solution, but it's better than it was, I think.

The more full solution would be to get a list of all names for the last election per seat, but that's a little out of scope for the time being :)