### PR TITLE
Fix YNR API calls

### DIFF
--- a/electionleaflets/apps/core/helpers.py
+++ b/electionleaflets/apps/core/helpers.py
@@ -58,7 +58,7 @@ class YNRAPIHelper:
         url = urljoin(self.YNR_BASE, path)
         params = params or {}
         params["auth_token"] = self.API_KEY
-        resp = session.get(url, params=params)
+        resp = session.get(url, params=params, timeout=10)
         resp.raise_for_status()
 
         if json:

--- a/electionleaflets/apps/core/tests/test_helpers.py
+++ b/electionleaflets/apps/core/tests/test_helpers.py
@@ -21,7 +21,9 @@ def test_ynr_get(settings):
 
         result = api_helper.get(endpoint)
 
-        mock_get.assert_called_once_with(expected_url, params=expected_params)
+        mock_get.assert_called_once_with(
+            expected_url, params=expected_params, timeout=10
+        )
         assert result == {"results": []}
 
 

--- a/electionleaflets/apps/core/tests/test_helpers.py
+++ b/electionleaflets/apps/core/tests/test_helpers.py
@@ -14,7 +14,7 @@ def test_ynr_get(settings):
 
     api_helper = YNRAPIHelper(api_key=ynr_api_key)
 
-    with patch("requests.get") as mock_get:
+    with patch("core.helpers.session.get") as mock_get:
         mock_response = mock_get.return_value
         mock_response.raise_for_status.return_value = None
         mock_response.json.return_value = {"results": []}

--- a/electionleaflets/apps/leaflets/forms.py
+++ b/electionleaflets/apps/leaflets/forms.py
@@ -3,6 +3,7 @@ import json
 from datetime import timedelta
 
 import requests
+import sentry_sdk
 from core.helpers import YNRAPIHelper
 from django import forms
 from django.core.signing import Signer
@@ -142,7 +143,8 @@ class YNRBallotDataMixin:
                     params=params,
                     json=True,
                 )
-            except requests.RequestException:
+            except requests.RequestException as e:
+                sentry_sdk.capture_exception(e)
                 return []
 
             self.storage.extra_data["ynr_data"] = resp["results"]

--- a/electionleaflets/apps/leaflets/forms.py
+++ b/electionleaflets/apps/leaflets/forms.py
@@ -7,6 +7,7 @@ from core.helpers import YNRAPIHelper
 from django import forms
 from django.core.signing import Signer
 from django.utils import timezone
+from formtools.wizard.storage import BaseStorage
 from leaflets.fields import DCDateField
 from leaflets.models import Leaflet, LeafletImage
 from localflavor.gb.forms import GBPostcodeField
@@ -113,7 +114,7 @@ class YNRBallotDataMixin:
     FOR_DATE = None
 
     def __init__(self, *args, **kwargs):
-        self.storage = kwargs.get("initial", {}).get("storage", None)
+        self.storage: BaseStorage = kwargs.pop("storage")
         super().__init__(*args, **kwargs)
 
     def get_date_range(self):

--- a/electionleaflets/apps/leaflets/views.py
+++ b/electionleaflets/apps/leaflets/views.py
@@ -95,17 +95,10 @@ class LeafletView(CacheControlMixin, DetailView):
     model = Leaflet
 
 
-def should_show_party_form(wizard):
-    party_form = wizard.get_form("party")
-    postcode_dict = wizard.get_cleaned_data_for_step("postcode")
-
-    if not postcode_dict:
-        return False
-    postcode = postcode_dict.get("postcode")
-    return party_form.get_ballot_data_from_ynr(postcode)
-
-
 def should_show_person_form(wizard):
+    if "party" not in wizard.storage.data["step_data"]:
+        return False
+
     cleaned_data = wizard.get_cleaned_data_for_step("party") or {}
     if not cleaned_data:
         return False

--- a/electionleaflets/apps/leaflets/views.py
+++ b/electionleaflets/apps/leaflets/views.py
@@ -146,7 +146,10 @@ class LeafletUploadWizzard(NamedUrlSessionWizardView):
             postcode = self.get_cleaned_data_for_step("postcode")
             if not postcode:
                 return None
-            ret = {"postcode": postcode.get("postcode")}
+            ret = {
+                "postcode": postcode.get("postcode"),
+                "storage": self.storage,
+            }
             try:
                 date = self.get_cleaned_data_for_step("date")["date"]
             except (KeyError, TypeError):

--- a/electionleaflets/apps/leaflets/views.py
+++ b/electionleaflets/apps/leaflets/views.py
@@ -134,6 +134,12 @@ class LeafletUploadWizzard(NamedUrlSessionWizardView):
         step_name = self.steps.current
         return [self.TEMPLATES[step_name]]
 
+    def get_form_kwargs(self, step=None):
+        kwargs = super().get_form_kwargs(step)
+        if step in ["party", "people"]:
+            kwargs["storage"] = self.storage
+        return kwargs
+
     def get_form_initial(self, step):
         if step in ["party", "people"]:
             postcode = self.get_cleaned_data_for_step("postcode")

--- a/electionleaflets/settings/base_lambda.py
+++ b/electionleaflets/settings/base_lambda.py
@@ -66,4 +66,6 @@ THUMBNAIL_BACKEND = "core.s3_thumbnail_store.S3Backend"
 CSRF_TRUSTED_ORIGINS = ["https://electionleaflets.org"]
 USE_X_FORWARDED_HOST = True
 
+YNR_API_KEY = os.environ["YNR_API_KEY"]  # Fail if not API key
+
 setup_sentry()  # noqa: F405

--- a/template.yaml
+++ b/template.yaml
@@ -71,6 +71,11 @@ Parameters:
     Description: "The DC_ENVIRONMENT environment variable passed to the app."
     Type: AWS::SSM::Parameter::Value<String>
 
+  AppYNRAPIKey:
+    Default: YNR_API_KEY
+    Description: "The YNR_API_KEY environment variable passed to the app."
+    Type: AWS::SSM::Parameter::Value<String>
+
   AppDomain:
     Description: "The domain the app is on."
     Type: String
@@ -121,6 +126,7 @@ Resources:
           DATABASE_USER: postgres
           APP_DOMAIN: !Ref AppDomain
           LEAFLET_IMAGES_BUCKET_NAME: !Ref AppLeafletImagesBucketName
+          YNR_API_KEY: !Ref AppYNRAPIKey
       Events:
         HTTPRequests:
           Type: Api


### PR DESCRIPTION
Turns out we were rate limiting ourselves and also calling YNR too much.

1. Each time we called the `get_form_initial` we were calling YNR. `get_form_initial` is called for each form, so on the last step we were calling it three times. 
2. We'd not set an API key, so we were sleeping for 6 seconds each time. This mixed with actual time taken to process he view meant we were timing out the Lambda function, most of the time.

This change caches the YNR response on the form/session and also sets a key. So we should only call YNR once, and then not sleep when we're doing so.

TODO: set the SSM values before merging.