### PR TITLE
Delete each thumb rather than scanning for matching thumbs

### DIFF
--- a/electionleaflets/apps/leaflets/models.py
+++ b/electionleaflets/apps/leaflets/models.py
@@ -203,6 +203,16 @@ class Leaflet(models.Model):
         next request.
         """
 
+        # IMPORTANT: These specs must be kept in sync with SPECS in thumbs/handler.py
+        SPECS = (
+            ("350", {"crop": "top"}),
+            ("150", {"crop": "noop"}),
+            ("1000", {"crop": "noop"}),
+            ("600", {"crop": "center"}),
+            ("350", {}),
+            ("600", {}),
+        )
+
         for leaflet_image in self.images.all():
             if not leaflet_image.image:
                 continue
@@ -213,10 +223,13 @@ class Leaflet(models.Model):
             if not hasattr(default_storage, "bucket"):
                 continue
 
-            stem = str(Path(leaflet_image.image.name).with_suffix(""))
-            for obj in default_storage.bucket.objects.filter(Prefix="thumbs/"):
-                if stem in obj.key:
-                    obj.delete()
+            stem = Path(leaflet_image.image.name).with_suffix("")
+            for size, options in SPECS:
+                option_parts = [size] + sorted(
+                    f"{k}={v}" for k, v in options.items()
+                )
+                key = "thumbs/{}/{}.png".format("/".join(option_parts), stem)
+                default_storage.bucket.Object(key).delete()
 
     def nuts1_name(self):
         return RegionChoices(self.nuts1).label

--- a/electionleaflets/apps/leaflets/models.py
+++ b/electionleaflets/apps/leaflets/models.py
@@ -1,3 +1,4 @@
+import json
 import os.path
 import re
 from io import BytesIO
@@ -7,6 +8,7 @@ import piexif
 import sentry_sdk
 from core.helpers import YNRAPIHelper
 from core.templatetags.markdown import markdown_filter
+from django.conf import settings
 from django.contrib.postgres.indexes import GinIndex
 from django.contrib.postgres.search import SearchVectorField
 from django.core.files.base import ContentFile
@@ -198,20 +200,16 @@ class Leaflet(models.Model):
 
     def clear_thumbs(self):
         """
-        Clears sorl's KV cache and deletes S3 thumb files for all images on
-        this leaflet. The thumbs Lambda will regenerate thumbs on
-        next request.
+        Clears sorl's KV cache and invokes the thumbs lambda to delete the
+        actual files. Next time those files are requested, they will be
+        re-made using the Lambda@Edge function attached to CloudFront
         """
 
-        # IMPORTANT: These specs must be kept in sync with SPECS in thumbs/handler.py
-        SPECS = (
-            ("350", {"crop": "top"}),
-            ("150", {"crop": "noop"}),
-            ("1000", {"crop": "noop"}),
-            ("600", {"crop": "center"}),
-            ("350", {}),
-            ("600", {}),
-        )
+        lambda_client = None
+        if hasattr(default_storage, "bucket"):
+            import boto3
+
+            lambda_client = boto3.client("lambda")
 
         for leaflet_image in self.images.all():
             if not leaflet_image.image:
@@ -220,16 +218,18 @@ class Leaflet(models.Model):
             # This is sorl's delete function, which clears the KV cache entry
             delete(leaflet_image.image, delete_file=False)
 
-            if not hasattr(default_storage, "bucket"):
-                continue
-
-            stem = Path(leaflet_image.image.name).with_suffix("")
-            for size, options in SPECS:
-                option_parts = [size] + sorted(
-                    f"{k}={v}" for k, v in options.items()
+            if lambda_client:
+                lambda_client.invoke(
+                    FunctionName=settings.THUMBS_LAMBDA_FUNCTION_NAME,
+                    # Event is non-blocking
+                    InvocationType="Event",
+                    Payload=json.dumps(
+                        {
+                            "action": "delete_thumbs",
+                            "key": leaflet_image.image.name,
+                        }
+                    ),
                 )
-                key = "thumbs/{}/{}.png".format("/".join(option_parts), stem)
-                default_storage.bucket.Object(key).delete()
 
     def nuts1_name(self):
         return RegionChoices(self.nuts1).label

--- a/electionleaflets/settings/base_lambda.py
+++ b/electionleaflets/settings/base_lambda.py
@@ -64,6 +64,9 @@ CACHES = {
 
 THUMBNAIL_KVSTORE = "sorl.thumbnail.kvstores.cached_db_kvstore.KVStore"
 THUMBNAIL_BACKEND = "core.s3_thumbnail_store.S3Backend"
+DC_ENVIRONMENT = os.environ["DC_ENVIRONMENT"]
+THUMBS_LAMBDA_FUNCTION_NAME = f"ElectionLeafletsThumbs-{DC_ENVIRONMENT}"
+
 
 CSRF_TRUSTED_ORIGINS = ["https://electionleaflets.org"]
 USE_X_FORWARDED_HOST = True

--- a/thumbs/handler.py
+++ b/thumbs/handler.py
@@ -124,6 +124,8 @@ def handle_cf(event, context):
 
 
 def handle_s3(event, context, local=False):
+    # IMPORTANT: These specs must be kept in sync with SPECS in
+    # electionleaflets/apps/leaflets/models.py
     SPECS = (
         ("350", {"crop": "top"}),
         ("150", {"crop": "noop"}),

--- a/thumbs/handler.py
+++ b/thumbs/handler.py
@@ -67,12 +67,24 @@ client = boto3.client("s3")
 engine = pil_engine.Engine()
 pillow_heif.register_heif_opener()
 
+SPECS = (
+    ("350", {"crop": "top"}),
+    ("150", {"crop": "noop"}),
+    ("1000", {"crop": "noop"}),
+    ("600", {"crop": "center"}),
+    ("350", {}),
+    ("600", {}),
+)
+
 
 def handle(event, context):
+    if event.get("action") == "delete_thumbs":
+        return handle_delete(event, context)
     if "s3" in event["Records"][0]:
         return handle_s3(event, context)
     if "cf" in event["Records"][0]:
         return handle_cf(event, context)
+
     return None
 
 
@@ -124,17 +136,6 @@ def handle_cf(event, context):
 
 
 def handle_s3(event, context, local=False):
-    # IMPORTANT: These specs must be kept in sync with SPECS in
-    # electionleaflets/apps/leaflets/models.py
-    SPECS = (
-        ("350", {"crop": "top"}),
-        ("150", {"crop": "noop"}),
-        ("1000", {"crop": "noop"}),
-        ("600", {"crop": "center"}),
-        ("350", {}),
-        ("600", {}),
-    )
-
     for r in event["Records"]:
         if not r["s3"]["object"]["key"].startswith("leaflets/"):
             continue
@@ -145,6 +146,14 @@ def handle_s3(event, context, local=False):
             processed = process_image(image, spec)
             key = new_key(spec, r["s3"]["object"]["key"])
             upload_image(processed, r["s3"]["bucket"]["name"], key)
+
+
+def handle_delete(event, context):
+    key = event["key"]  # e.g. "leaflets/foo.jpg"
+    path = Path(key)
+    for spec in SPECS:
+        thumb_key = new_key(spec, path).with_suffix(".png")
+        client.delete_object(Bucket=BUCKET_NAME, Key=str(thumb_key))
 
 
 def fetch_image(bucket: str, key: Path):

--- a/thumbs/template.yml
+++ b/thumbs/template.yml
@@ -8,11 +8,17 @@ Globals:
   Api:
     BinaryMediaTypes:
       - "*/*"
+Parameters:
+  DCEnvironment:
+    Default: DC_ENVIRONMENT
+    Description: "The DC_ENVIRONMENT environment variable passed to the app."
+    Type: AWS::SSM::Parameter::Value<String>
 
 Resources:
   ThumbsFunction:
     Type: AWS::Serverless::Function
     Properties:
+      FunctionName: !Sub "ElectionLeafletsThumbs-${DCEnvironment}"
       Role: !Sub "arn:aws:iam::${AWS::AccountId}:role/ElectionLeafletsLambdaExecutionRole"
       CodeUri: .
       Handler: handler.handle


### PR DESCRIPTION
In the last commit I ended up scanning the whole bucket for any thumb that matched. This was very slow as it was really scanning _all_ thumbs in the bucket.

We know the exact location of these, as we hand-make them in the Lambda@Edge function.

This change duplicates the SPECS dict, but means we don't need to scan S3 at all. I looked into ways of sharing the dict, but all seemed too complex for a little duplication. Hupefully the comment will help us remember to keep them in sync
